### PR TITLE
Added build query option for searching raw records

### DIFF
--- a/bin/test
+++ b/bin/test
@@ -6,7 +6,7 @@ file --mime-type ./* bin/* | grep 'text/x-shellscript' | cut -d':' -f1 |
     xargs -r shellcheck
 
 echo -e "\n=== RuboCop"
-rubocop
+rubocop -A
 
 echo -e "\n=== RSpec"
 rspec

--- a/bin/test
+++ b/bin/test
@@ -6,7 +6,7 @@ file --mime-type ./* bin/* | grep 'text/x-shellscript' | cut -d':' -f1 |
     xargs -r shellcheck
 
 echo -e "\n=== RuboCop"
-rubocop -A
+rubocop
 
 echo -e "\n=== RSpec"
 rspec

--- a/lib/register_sources_sk/repositories/record_repository.rb
+++ b/lib/register_sources_sk/repositories/record_repository.rb
@@ -79,6 +79,7 @@ module RegisterSourcesSk
         true
       end
 
+      # rubocop:disable Metrics/CyclomaticComplexity
       def build_get_by_bods_identifiers(identifiers)
         icos = [] # record.PartneriVerejnehoSektora.Ico
         ids = [] # sk_record.KonecniUzivateliaVyhod.Id
@@ -101,18 +102,18 @@ module RegisterSourcesSk
                   must: [
                     {
                       nested: {
-                        path: "data.PartneriVerejnehoSektora",
+                        path: 'data.PartneriVerejnehoSektora',
                         query: {
                           bool: {
                             must: [
-                              { match: { 'data.PartneriVerejnehoSektora.Ico': { query: ico } } },
-                            ],
-                          },
-                        },
-                      },
-                    },
-                  ],
-                },
+                              { match: { 'data.PartneriVerejnehoSektora.Ico': { query: ico } } }
+                            ]
+                          }
+                        }
+                      }
+                    }
+                  ]
+                }
               }
             } + ids.map do |id|
               {
@@ -120,23 +121,24 @@ module RegisterSourcesSk
                   must: [
                     {
                       nested: {
-                        path: "data.KonecniUzivateliaVyhod",
+                        path: 'data.KonecniUzivateliaVyhod',
                         query: {
                           bool: {
                             must: [
-                              { match: { 'data.KonecniUzivateliaVyhod.Id': { query: id } } },
-                            ],
-                          },
-                        },
-                      },
-                    },
-                  ],
-                },
+                              { match: { 'data.KonecniUzivateliaVyhod.Id': { query: id } } }
+                            ]
+                          }
+                        }
+                      }
+                    }
+                  ]
+                }
               }
-            end,
-          },
+            end
+          }
         }
       end
+      # rubocop:enable Metrics/CyclomaticComplexity
 
       private
 
@@ -152,7 +154,7 @@ module RegisterSourcesSk
         SearchResults.new(
           mapped.sort_by(&:score).reverse,
           total_count:,
-          aggs: results['aggregations'],
+          aggs: results['aggregations']
         )
       end
 

--- a/spec/integration/record_repository_spec.rb
+++ b/spec/integration/record_repository_spec.rb
@@ -5,8 +5,6 @@ require 'register_sources_sk/repositories/record_repository'
 require 'register_sources_sk/services/es_index_creator'
 require 'register_sources_sk/structs/record'
 
-BodsIdentifier = Struct.new(:id, :schemeName)
-
 RSpec.describe RegisterSourcesSk::Repositories::RecordRepository do
   subject { described_class.new(client: es_client, index:) }
 
@@ -39,36 +37,6 @@ RSpec.describe RegisterSourcesSk::Repositories::RecordRepository do
 
       # When records do not exist
       expect(subject.get('missing')).to be_nil
-    end
-  end
-
-  describe '#get_by_bods_identifiers' do
-    it 'retrieves' do
-      records = [record]
-
-      subject.store(records)
-
-      sleep 1 # eventually consistent, give time
-
-      id_identifiers = [
-        BodsIdentifier.new('3', 'SK Register Partnerov Verejného Sektora')
-      ]
-      expect(subject.get_by_bods_identifiers(id_identifiers)).to eq [record]
-
-      ico_identifiers = [
-        BodsIdentifier.new('1234567', 'Ministry of Justice Business Register')
-      ]
-      expect(subject.get_by_bods_identifiers(ico_identifiers)).to eq [record]
-
-      missing_id_identifiers = [
-        BodsIdentifier.new('10', 'SK Register Partnerov Verejného Sektora')
-      ]
-      expect(subject.get_by_bods_identifiers(missing_id_identifiers)).to eq []
-
-      missing_ico_identifiers = [
-        BodsIdentifier.new('1234568', 'Ministry of Justice Business Register')
-      ]
-      expect(subject.get_by_bods_identifiers(missing_ico_identifiers)).to eq []
     end
   end
 end

--- a/spec/unit/repositories/record_repository_spec.rb
+++ b/spec/unit/repositories/record_repository_spec.rb
@@ -157,12 +157,11 @@ RSpec.describe RegisterSourcesSk::Repositories::RecordRepository do
     end
   end
 
-  # rubocop:disable RSpec/ExampleLength
   describe '#build_get_by_bods_identifiers' do
     it 'builds query for searching by bods identifiers' do
       identifiers = [
-        BodsIdentifier.new("3", 'SK Register Partnerov Verejného Sektora'),
-        BodsIdentifier.new("1234567", 'Ministry of Justice Business Register'),
+        BodsIdentifier.new('3', 'SK Register Partnerov Verejného Sektora'),
+        BodsIdentifier.new('1234567', 'Ministry of Justice Business Register')
       ]
 
       query = subject.build_get_by_bods_identifiers(identifiers)
@@ -176,54 +175,53 @@ RSpec.describe RegisterSourcesSk::Repositories::RecordRepository do
                   must: [
                     {
                       nested: {
-                        path: "data.PartneriVerejnehoSektora",
+                        path: 'data.PartneriVerejnehoSektora',
                         query: {
                           bool: {
                             must: [
                               {
                                 match: {
                                   'data.PartneriVerejnehoSektora.Ico': {
-                                    query: "1234567",
-                                  },
-                                },
-                              },
-                            ],
-                          },
-                        },
-                      },
-                    },
-                  ],
-                },
+                                    query: '1234567'
+                                  }
+                                }
+                              }
+                            ]
+                          }
+                        }
+                      }
+                    }
+                  ]
+                }
               },
               {
                 bool: {
                   must: [
                     {
                       nested: {
-                        path: "data.KonecniUzivateliaVyhod",
+                        path: 'data.KonecniUzivateliaVyhod',
                         query: {
                           bool: {
                             must: [
                               {
                                 match: {
                                   'data.KonecniUzivateliaVyhod.Id': {
-                                    query: "3",
-                                  },
-                                },
-                              },
-                            ],
-                          },
-                        },
-                      },
-                    },
-                  ],
-                },
-              },
-            ],
-          },
-        },
+                                    query: '3'
+                                  }
+                                }
+                              }
+                            ]
+                          }
+                        }
+                      }
+                    }
+                  ]
+                }
+              }
+            ]
+          }
+        }
       )
     end
-    # rubocop:enable RSpec/ExampleLength
   end
 end

--- a/spec/unit/repositories/record_repository_spec.rb
+++ b/spec/unit/repositories/record_repository_spec.rb
@@ -2,6 +2,8 @@
 
 require 'register_sources_sk/repositories/record_repository'
 
+BodsIdentifier = Struct.new(:id, :schemeName)
+
 RSpec.describe RegisterSourcesSk::Repositories::RecordRepository do
   subject { described_class.new(client:, index:) }
 
@@ -153,5 +155,75 @@ RSpec.describe RegisterSourcesSk::Repositories::RecordRepository do
         end
       end
     end
+  end
+
+  # rubocop:disable RSpec/ExampleLength
+  describe '#build_get_by_bods_identifiers' do
+    it 'builds query for searching by bods identifiers' do
+      identifiers = [
+        BodsIdentifier.new("3", 'SK Register Partnerov Verejného Sektora'),
+        BodsIdentifier.new("1234567", 'Ministry of Justice Business Register'),
+      ]
+
+      query = subject.build_get_by_bods_identifiers(identifiers)
+
+      expect(query).to eq(
+        {
+          bool: {
+            should: [
+              {
+                bool: {
+                  must: [
+                    {
+                      nested: {
+                        path: "data.PartneriVerejnehoSektora",
+                        query: {
+                          bool: {
+                            must: [
+                              {
+                                match: {
+                                  'data.PartneriVerejnehoSektora.Ico': {
+                                    query: "1234567",
+                                  },
+                                },
+                              },
+                            ],
+                          },
+                        },
+                      },
+                    },
+                  ],
+                },
+              },
+              {
+                bool: {
+                  must: [
+                    {
+                      nested: {
+                        path: "data.KonecniUzivateliaVyhod",
+                        query: {
+                          bool: {
+                            must: [
+                              {
+                                match: {
+                                  'data.KonecniUzivateliaVyhod.Id': {
+                                    query: "3",
+                                  },
+                                },
+                              },
+                            ],
+                          },
+                        },
+                      },
+                    },
+                  ],
+                },
+              },
+            ],
+          },
+        },
+      )
+    end
+    # rubocop:enable RSpec/ExampleLength
   end
 end


### PR DESCRIPTION
The Register needs to be able to combine and submit the queries as a single query over multiple indexes, to properly paginate raw record requests over multiple sources.

To allow this, the query for raw records is now built and returned instead of being performed inside the repository.